### PR TITLE
Change dependency to newly released v8.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Stability : Experimental, work (very much) in early stages.
 1) Install the module with composer
 ```bash
 composer config repositories.cmtickle/module-elastic-apm vcs https://github.com/cmtickle/elastic-apm-magento.git
-composer config repositories.nipwaayoni/elastic-apm-php-agent vcs https://github.com/cmtickle/elastic-apm-php-agent.git
 composer require cmtickle/module-elastic-apm:dev-develop  nipwaayoni/elastic-apm-php-agent:dev-elastic-apm-magento@dev
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "magento/framework": ">=101.0.0",
-        "nipwaayoni/elastic-apm-php-agent": "dev-elastic-apm-magento@dev"
+        "nipwaayoni/elastic-apm-php-agent": "dev-8.1-dev#2a4baba"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "magento/framework": ">=101.0.0",
-        "nipwaayoni/elastic-apm-php-agent": "dev-8.1-dev#2a4baba@dev"
+        "nipwaayoni/elastic-apm-php-agent": "v8.1.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "magento/framework": ">=101.0.0",
-        "nipwaayoni/elastic-apm-php-agent": "dev-8.1-dev#2a4baba"
+        "nipwaayoni/elastic-apm-php-agent": "dev-8.1-dev#2a4baba@dev"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
The dependency have merged (a version of) my fix. We can now revert to using the main distribution.